### PR TITLE
1 set wifi hostname of esp32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.0.1] - 2023/12/29
+
+### Added
+
+- Setting the hostname of the ESP32 via the WiFi library to match the `DEVICE_ID` specified in the `credentials.h` file.
+- Added serial printing of the set IP address and hostname via the `Serial` device. This is useful when debugging.
+
 ## [v1.0.0] - 2023/11/3
 
 ### Added

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -23,6 +23,8 @@ void connectWiFi()
   Serial.printf("SSID: %s \n", WIFI_SSID);
   Serial.printf("Password: %s \n", WIFI_PASSWORD);
 
+  WiFi.setHostname(DEVICE_ID);
+  WiFi.mode(WIFI_STA);
   WiFi.begin(WIFI_SSID, WIFI_PASSWORD);
   while (WiFi.status() != WL_CONNECTED)
   {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,6 +32,8 @@ void connectWiFi()
     delay(1000);
   }
   Serial.println("\nWiFi connected!");
+  Serial.printf("IP Address: %s \n", WiFi.localIP());
+  Serial.printf("Hostname: %s \n", WiFi.getHostname());
 }
 
 void connectMQTT()


### PR DESCRIPTION
Addressing the need to be able to set the hostname of the ESP32 device. This will be useful as more sensors get added to the network (which will happen pretty soon as I have the PCBs).